### PR TITLE
Adding index-url for virtkey

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+--extra-index-url=https://launchpad.net
 virtkey


### PR DESCRIPTION
`virtkey` can't be found at `pypi`